### PR TITLE
feat: support for ignoredPaths

### DIFF
--- a/custom-dictionary.txt
+++ b/custom-dictionary.txt
@@ -5,3 +5,4 @@ lnum
 nvim
 readfile
 writefile
+bufname

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -42,7 +42,7 @@ return h.make_builtin({
                 "lint",
                 "--language-id",
                 params.ft,
-                "stdin",
+                "stdin://" .. params.bufname,
             }
 
             local code_action_source = require("null-ls.sources").get({

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -92,6 +92,8 @@ end
 
 ---@class GeneratorParams
 ---@field bufnr number
+---@field bufname string
+---@field ft string
 ---@field row number
 ---@field col number
 ---@field cwd string

--- a/tests/spec/diagnostics_spec.lua
+++ b/tests/spec/diagnostics_spec.lua
@@ -52,7 +52,10 @@ describe("diagnostics", function()
                 async_get_config_info = stub(helpers, "async_get_config_info")
                 get_source = stub(require("null-ls.sources"), "get")
                 get_source.returns({})
-                args = args_fn({ ft = "lua" })
+                args = args_fn({
+                    ft = "lua",
+                    bufname = "file.txt",
+                })
             end)
 
             after_each(function()
@@ -69,7 +72,7 @@ describe("diagnostics", function()
                     "lint",
                     "--language-id",
                     "lua",
-                    "stdin",
+                    "stdin://file.txt",
                 }, args)
             end)
         end)
@@ -81,6 +84,7 @@ describe("diagnostics", function()
                 get_source.returns({ code_actions })
                 args = args_fn({
                     ft = "lua",
+                    bufname = "file.txt",
                     get_config = function()
                         return {}
                     end,
@@ -102,7 +106,7 @@ describe("diagnostics", function()
                     "lint",
                     "--language-id",
                     "lua",
-                    "stdin",
+                    "stdin://file.txt",
                 }, args)
             end)
         end)


### PR DESCRIPTION
A list of ignored paths can be added to the CSpell config. We need to support both stdin to check against unsaved changes and also have CSpell understand which file we're evaluating.

So we're replacing the `stdin` param with `stdin://<path>`, which covers both cases.

Resolves #8