### PR TITLE
chore: make sure diagnostics read the same config file as code action

### DIFF
--- a/custom-dictionary.txt
+++ b/custom-dictionary.txt
@@ -6,3 +6,5 @@ nvim
 readfile
 writefile
 bufname
+luassert
+realpath

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -45,6 +45,11 @@ return h.make_builtin({
                 "stdin://" .. params.bufname,
             }
 
+            local config_path = helpers.get_config_path(params)
+            if config_path then
+                cspell_args = vim.list_extend({ "-c", config_path }, cspell_args)
+            end
+
             local code_action_source = require("null-ls.sources").get({
                 name = "cspell",
                 method = methods.internal.CODE_ACTION,

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -195,6 +195,11 @@ M.set_word = function(diagnostic, new_word)
     )
 end
 
+M.clear_cache = function()
+    PATH_BY_CWD = {}
+    CONFIG_INFO_BY_CWD = {}
+end
+
 return M
 
 ---@class Diagnostic

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -13,6 +13,7 @@ local CSPELL_CONFIG_FILES = {
 
 ---@type table<string, CSpellConfigInfo|nil>
 local CONFIG_INFO_BY_CWD = {}
+local PATH_BY_CWD = {}
 
 --- create a bare minimum cspell.json file
 ---@param params GeneratorParams
@@ -104,10 +105,9 @@ end
 M.get_cspell_config = function(params)
     ---@type CSpellSourceConfig
     local code_action_config = params:get_config()
-    local find_json = code_action_config.find_json or find_cspell_config_path
     local decode_json = code_action_config.decode_json or vim.json.decode
 
-    local cspell_json_path = find_json(params.cwd)
+    local cspell_json_path = M.get_config_path(params)
 
     if cspell_json_path == nil or cspell_json_path == "" then
         return
@@ -145,6 +145,16 @@ M.async_get_config_info = function(params)
     async:send()
 
     return CONFIG_INFO_BY_CWD[params.cwd]
+end
+
+M.get_config_path = function(params)
+    if PATH_BY_CWD[params.cwd] == nil then
+        local code_action_config = params:get_config()
+        local find_json = code_action_config.find_json or find_cspell_config_path
+        local cspell_json_path = find_json(params.cwd)
+        PATH_BY_CWD[params.cwd] = cspell_json_path
+    end
+    return PATH_BY_CWD[params.cwd]
 end
 
 --- Checks that both sources use the same config


### PR DESCRIPTION
I have no idea how come it worked before. For me,I have to set the `-c` parameter to make sure when the config path is customized (meaning `find_json` is set), both code_action and diagnostics read the same file.