### PR TITLE
chore: favor the upstream fix for multi-byte chars

### DIFF
--- a/lua/cspell/diagnostics/parser.lua
+++ b/lua/cspell/diagnostics/parser.lua
@@ -18,36 +18,15 @@ local custom_user_data = {
     end,
 }
 
---- CSpell doesn't care about multi-byte characters when calculating the
---- column number for the start of the error. Forwarding the column number
---- as reported by CSpell, would cause the error to be diagnostic to highlight
---- the wrong range.
---- So we delegate that value as a helper property that will help us find the
---- start and end of the word.
-local custom_from_quote = {
-    end_col = function(entries, line)
-        local quote = entries["_quote"]
-        --- We use the column reported by CSpell as the start index to find the
-        --- current word in the line, in case the word shows up multiple times
-        --- in the same line.
-        local col, end_col = line:find(quote, entries["_col"], true)
-        --- HACK: Since the column reported by CSpell may not match the column
-        --- as counted by lua, we're mutating the entries table to define the
-        --- column property here, so we can account for special characters.
-        entries["col"] = col
-        return end_col + 1
-    end,
-}
-
 -- Finds the messages including a suggestions array, which comes from passing
 -- the --show-suggestions flag to cspell.
 -- That flag is only available when the user has registered the code action.
 local matcher_with_suggestions = {
     pattern = ".*:(%d+):(%d+)%s*-%s*(.*%((.*)%))%s*Suggestions:%s*%[(.*)%]",
-    groups = { "row", "_col", "message", "_quote", "_suggestions" },
+    groups = { "row", "col", "message", "_quote", "_suggestions" },
     overrides = {
         adapters = {
-            custom_from_quote,
+            h.diagnostics.adapters.end_col.from_quote,
             custom_user_data,
         },
     },
@@ -59,10 +38,10 @@ local matcher_with_suggestions = {
 -- used by the code actions.
 local matcher_without_suggestions = {
     pattern = [[.*:(%d+):(%d+)%s*-%s*(.*%((.*)%))]],
-    groups = { "row", "_col", "message", "_quote" },
+    groups = { "row", "col", "message", "_quote" },
     overrides = {
         adapters = {
-            custom_from_quote,
+            h.diagnostics.adapters.end_col.from_quote,
         },
     },
 }

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,2 +1,1 @@
 indent_type = "Spaces"
-indent_width = 4

--- a/tests/spec/diagnostics_spec.lua
+++ b/tests/spec/diagnostics_spec.lua
@@ -19,11 +19,10 @@ describe("diagnostics", function()
 
         it("should create a diagnostic", function()
             local output = "/some/path/file.lua:1:18 - Unknown word (variabl)"
-            local diagnostic = parser(output, { content = { content } })
+            local diagnostic = parser(output, { content = content })
 
             assert.same({
-                col = 18,
-                end_col = 25,
+                col = "18",
                 message = "Unknown word (variabl)",
                 row = "1",
             }, diagnostic)
@@ -32,11 +31,10 @@ describe("diagnostics", function()
         it("includes suggestions", function()
             local output =
                 "/some/path/file.lua:1:18 - Unknown word (variabl) Suggestions: [variable, variably, variables, variant, variate]"
-            local diagnostic = parser(output, { content = { content } })
+            local diagnostic = parser(output, { content = content })
 
             assert.same({
-                col = 18,
-                end_col = 25,
+                col = "18",
                 message = "Unknown word (variabl)",
                 row = "1",
                 user_data = {


### PR DESCRIPTION
This reverts commit d21276d92b2984d47bd5cb0a1f662c288b0743de.

A better fix is now applied in none-ls:
https://github.com/nvimtools/none-ls.nvim/pull/36