### PR TITLE
Fix .cSpell.json config file name

### DIFF
--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -7,7 +7,7 @@ local CSPELL_CONFIG_FILES = {
     "cspell.json",
     ".cspell.json",
     "cSpell.json",
-    ".cspell.json",
+    ".cSpell.json",
     ".cspell.config.json",
 }
 


### PR DESCRIPTION
There were two '.cspell.json' lower case entries.
