### PR TITLE
fix: avoid save buffer prompts due to JSON / dict actions

### DIFF
--- a/lua/cspell/code_actions/make_add_to_dictionary_action.lua
+++ b/lua/cspell/code_actions/make_add_to_dictionary_action.lua
@@ -44,6 +44,7 @@ return function(opts)
 
             -- replace word in buffer to trigger cspell to update diagnostics
             h.set_word(opts.diagnostic, opts.word)
+            vim.cmd([[:silent :undo]])
 
             if on_success then
                 vim.notify_once(

--- a/lua/cspell/code_actions/make_add_to_json.lua
+++ b/lua/cspell/code_actions/make_add_to_json.lua
@@ -47,6 +47,7 @@ return function(opts)
 
             -- replace word in buffer to trigger cspell to update diagnostics
             h.set_word(opts.diagnostic, opts.word)
+            vim.cmd([[:silent :undo]])
 
             if on_success then
                 vim.notify_once(


### PR DESCRIPTION
Text changes in these actions are only to update diagnostics, but they
cause the buffers to be marked as changed, so Neovim asks users whether
they want to save them before exiting.

---

Ideally we should delete the entry from undo history so users cannot
redo either. But it didn't seem easy to achieve...
