### PR TITLE
fix: avoid overwriting JSON with a default one when async is enabled

### DIFF
--- a/lua/cspell/code_actions/init.lua
+++ b/lua/cspell/code_actions/init.lua
@@ -111,7 +111,6 @@ return make_builtin({
                         diagnostic = diagnostic,
                         word = word,
                         params = params,
-                        cspell = cspell,
                     })
                 )
 

--- a/tests/spec/diagnostics_spec.lua
+++ b/tests/spec/diagnostics_spec.lua
@@ -1,6 +1,8 @@
 local mock = require("luassert.mock")
 local stub = require("luassert.stub")
 
+local Path = require("plenary.path")
+
 local diagnostics = require("cspell.diagnostics")
 local code_actions = require("cspell.code_actions")
 local helpers = require("cspell.helpers")
@@ -158,6 +160,166 @@ describe("diagnostics", function()
                     "lua",
                     "stdin://file.txt",
                 }, args)
+            end)
+        end)
+
+        describe("with read_config_synchronously = false,", function()
+            local orig_config_str = Path:new(CSPELL_CONFIG_PATH):read()
+            local config
+            local vim_diagnostic
+            local vim_api_nvim_buf_get_text
+            local vim_api_nvim_buf_set_text
+            local misspelled = "variabl"
+            local existing_word = "foo"
+            local sync_get_config_info
+            local vim_loop_new_async = vim.loop.new_async
+
+            -- fixtures
+            local buf_diagnostics = {
+                {
+                    bufnr = 1890,
+                    col = 17,
+                    end_col = 24,
+                    end_lnum = 0,
+                    lnum = 0,
+                    message = string.format("Unknown word (%s)", misspelled),
+                    namespace = 35,
+                    row = "1",
+                    severity = 2,
+                    source = "cspell",
+                    user_data = {
+                        misspelled = misspelled,
+                        suggestions = { "variable", "variably", "varia", "varian", "variant" },
+                    },
+                },
+            }
+            local generator_params = {
+                cwd = vim.loop.cwd(),
+                ft = "lua",
+                bufnr = 1890,
+                row = "1",
+                col = 17,
+                get_config = function()
+                    return {
+                        read_config_synchronously = false,
+                    }
+                end,
+            }
+
+            local get_add_to_json_action = function()
+                local add_to_json_action
+                local actions = code_actions.generator.fn(generator_params)
+                for _, action in ipairs(actions) do
+                    if action.title:match("cspell json file") then
+                        add_to_json_action = action
+                        break
+                    end
+                end
+                return add_to_json_action
+            end
+
+            before_each(function()
+                helpers.clear_cache()
+                config = vim.json.decode(orig_config_str)
+                config.words[#config.words + 1] = existing_word
+                Path:new(CSPELL_CONFIG_PATH):write(vim.json.encode(config), "w")
+
+                vim_diagnostic = stub(vim.diagnostic, "get")
+                vim_diagnostic.returns(buf_diagnostics)
+                vim_api_nvim_buf_get_text = stub(vim.api, "nvim_buf_get_text")
+                vim_api_nvim_buf_get_text.returns({ { misspelled } })
+                vim_api_nvim_buf_set_text = stub(vim.api, "nvim_buf_set_text")
+
+                -- avoid async otherwise it writes after our tests
+                vim.loop.new_async = function(callback)
+                    return {
+                        send = callback,
+                        close = function() end,
+                    }
+                end
+            end)
+
+            after_each(function()
+                Path:new(CSPELL_CONFIG_PATH):write(orig_config_str, "w")
+                vim_diagnostic:revert()
+                vim_api_nvim_buf_get_text:revert()
+                vim_api_nvim_buf_set_text:revert()
+                vim.loop.new_async = vim_loop_new_async
+            end)
+
+            describe("config file has been read", function()
+                before_each(function()
+                    async_get_config_info = stub(helpers, "async_get_config_info")
+                    async_get_config_info.returns({
+                        config = config,
+                        path = CSPELL_CONFIG_PATH,
+                    })
+                end)
+
+                after_each(function()
+                    async_get_config_info:revert()
+                end)
+
+                it("can add the misspelled word to JSON via an action", function()
+                    local add_to_json_action = get_add_to_json_action()
+
+                    assert.is_not_nil(add_to_json_action)
+                    add_to_json_action.action({
+                        diagnostic = buf_diagnostics[1],
+                        word = misspelled,
+                        params = generator_params,
+                    })
+
+                    assert.stub(vim_api_nvim_buf_get_text).was_called()
+                    assert.stub(vim_api_nvim_buf_set_text).was_called()
+
+                    local updated_config = vim.json.decode(Path:new(CSPELL_CONFIG_PATH):read())
+                    assert.is_table(updated_config.words)
+                    assert.truthy(vim.tbl_contains(updated_config.words, misspelled))
+                    assert.truthy(vim.tbl_contains(updated_config.words, existing_word))
+                end)
+            end)
+
+            describe("config reading is in progress", function()
+                before_each(function()
+                    async_get_config_info = stub(helpers, "async_get_config_info")
+                    async_get_config_info.returns(nil)
+                    sync_get_config_info = stub(helpers, "sync_get_config_info")
+                    sync_get_config_info.returns({ config = config, path = CSPELL_CONFIG_PATH })
+                end)
+
+                after_each(function()
+                    async_get_config_info:revert()
+                    sync_get_config_info:revert()
+                end)
+
+                it("caches the misspelled word and adds it to JSON after reading", function()
+                    local add_to_json_action = get_add_to_json_action()
+
+                    assert.is_not_nil(add_to_json_action)
+                    add_to_json_action.action({
+                        diagnostic = buf_diagnostics[1],
+                        word = misspelled,
+                        params = generator_params,
+                    })
+
+                    local updated_config = vim.json.decode(Path:new(CSPELL_CONFIG_PATH):read())
+                    assert.is_table(updated_config.words)
+                    assert.truthy(vim.tbl_contains(updated_config.words, existing_word))
+                    assert.stub(async_get_config_info).was_called()
+                    assert.stub(sync_get_config_info).was_not_called()
+                    assert.stub(vim_api_nvim_buf_get_text).was_called()
+                    assert.stub(vim_api_nvim_buf_set_text).was_not_called()
+
+                    async_get_config_info:revert()
+                    get_add_to_json_action()
+
+                    updated_config = vim.json.decode(Path:new(CSPELL_CONFIG_PATH):read())
+                    assert.is_table(updated_config.words)
+                    assert.truthy(vim.tbl_contains(updated_config.words, existing_word))
+                    assert.truthy(vim.tbl_contains(updated_config.words, misspelled))
+                    assert.stub(sync_get_config_info).was_called()
+                end)
             end)
         end)
     end)


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
When read_config_synchronously = false, as the actions are often
generated before the JSON is read, when an action is executed,
it could overwrite an existing JSON config with a default one due to
opts.cspell being empty.

So first of all, this patch makes a fresh query to CONFIG_INFO_BY_CWD,
which allows actions to correctly reuse it if the async reading is done.

If the async reading is still in-progress, the misspelled word is cached
in CACHED_JSON_WORDS, and gets added with other cached words once the
reading is done.
<!-- === GH HISTORY FENCE === -->
