### PR TITLE
fix(code_actions): absolute path support

### DIFF
--- a/lua/cspell/code_actions/make_add_to_dictionary_action.lua
+++ b/lua/cspell/code_actions/make_add_to_dictionary_action.lua
@@ -1,3 +1,4 @@
+local Path = require("plenary.path")
 local h = require("cspell.helpers")
 
 ---@class AddToDictionaryAction
@@ -27,7 +28,7 @@ return function(opts)
             if opts.dictionary == nil then
                 return
             end
-            local dictionary_path = vim.fn.expand(opts.dictionary.path)
+            local dictionary_path = Path:new(opts.cspell.path):parent():joinpath(opts.dictionary.path):absolute()
             local dictionary_ok, dictionary_body = pcall(vim.fn.readfile, dictionary_path)
             if not dictionary_ok then
                 vim.notify("Can't read " .. dictionary_path, vim.log.levels.ERROR, { title = "cspell.nvim" })


### PR DESCRIPTION
When a CSpell config is loaded from a custom location, the paths for the dictionary files need to be resolved relative to the config file.

Resolves #53