### PR TITLE
Multi config fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !.yarn/versions
 node_modules/
 .tests/
+.direnv

--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@ local config = {
   -- See the currently supported files in https://github.com/davidmh/cspell.nvim/blob/main/lua/cspell/helpers.lua
   config_file_preferred_name = 'cspell.json',
 
+  -- A list of directories that contain additional cspell.json config files or
+  -- support the creation of a new config file from a code action
+  --
+  -- looks for a cspell config in the ~/.config/ directory, or creates a file in the directory
+  -- using 'config_file_preferred_name' when a code action for one of the locations is selected
+  cspell_config_dirs = { "~/.config/" }
+
   --- A way to define your own logic to find the CSpell configuration file.
-  ---@params cwd The same current working directory defined in the source,
+  ---@params directory The same directory defined in the source,
   --             defaulting to vim.loop.cwd()
   ---@return string|nil The path of the json file
-  find_json = function(cwd)
+  find_json = function(directory)
   end,
 
   -- Will find and read the cspell config file synchronously, as soon as the

--- a/custom-dictionary.txt
+++ b/custom-dictionary.txt
@@ -10,3 +10,8 @@ luassert
 realpath
 neotest
 Neovim
+stdpath
+joinpath
+fnamemodify
+itable
+fnameescape

--- a/lua/cspell/code_actions/make_add_to_dictionary_action.lua
+++ b/lua/cspell/code_actions/make_add_to_dictionary_action.lua
@@ -21,9 +21,14 @@ return function(opts)
     -- user_data. And only use the word from the range to trigger a new diagnostic.
     -- See: https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1630
     local misspelled_word = opts.diagnostic.user_data.misspelled
+    local dictionary = opts.dictionary.name
+    local shortened_path = h.shorten_path(opts.cspell.path)
 
     return {
-        title = 'Add "' .. misspelled_word .. '" to dictionary "' .. opts.dictionary.name .. '"',
+        title = h.format(
+            'Add "${word}" to dictionary "${dictionary}" from "${config_path}"',
+            { word = misspelled_word, dictionary = dictionary, config_path = shortened_path }
+        ),
         action = function()
             if opts.dictionary == nil then
                 return

--- a/lua/cspell/code_actions/make_add_to_json.lua
+++ b/lua/cspell/code_actions/make_add_to_json.lua
@@ -4,6 +4,7 @@ local h = require("cspell.helpers")
 ---@class AddToJSONAction
 ---@field diagnostic Diagnostic
 ---@field word string
+---@field cspell_config_path string
 ---@field params GeneratorParams
 
 ---@param opts AddToJSONAction
@@ -17,22 +18,28 @@ return function(opts)
     local misspelled_word = opts.diagnostic.user_data.misspelled
 
     return {
-        title = 'Add "' .. misspelled_word .. '" to cspell json file',
+        title = h.format(
+            'Add "${word}" to "${config_path}"',
+            { word = misspelled_word, config_path = h.shorten_path(opts.cspell_config_path) }
+        ),
+
         action = function()
+            local cspell_config_path = opts.cspell_config_path
             -- get a fresh config when the action is performed, which can be much later than when the action was generated
-            local cspell = h.async_get_config_info(opts.params)
-            local config_path = h.get_config_path(opts.params)
-            if not cspell and config_path and Path:new(config_path):exists() then
+            local cspell = h.async_get_config_info(opts.params, cspell_config_path)
+            local path_exists = Path:new(cspell_config_path):exists()
+            if not cspell and path_exists then
                 h.cache_word_for_json(misspelled_word)
                 return
             end
-            cspell = cspell or h.create_cspell_json(opts.params)
+
+            cspell = cspell or h.create_default_cspell_json(opts.params, cspell_config_path)
 
             if not cspell.config.words then
                 cspell.config.words = {}
             end
 
-            h.add_words_to_json(opts.params, { misspelled_word })
+            h.add_words_to_json(opts.params, { misspelled_word }, cspell_config_path)
 
             -- replace word in buffer to trigger cspell to update diagnostics
             h.set_word(opts.diagnostic, opts.word)

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -19,19 +19,33 @@ return h.make_builtin({
         command = "cspell",
         ---@param params GeneratorParams
         args = function(params)
-            params.cwd = params.cwd or vim.loop.cwd()
-
             local cspell_args = {
                 "lint",
                 "--language-id",
                 params.ft,
                 "stdin://" .. params.bufname,
             }
+            params.cwd = params.cwd or vim.loop.cwd()
 
-            local config_path = helpers.get_config_path(params)
-            if config_path then
-                cspell_args = vim.list_extend({ "-c", config_path }, cspell_args)
+            ---@type CSpellSourceConfig
+            local diagnostics_config = params and params:get_config() or {}
+
+            ---@type table<number|string, string>
+            local cspell_config_paths = {}
+
+            local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
+            table.insert(cspell_config_directories, params.cwd)
+
+            for _, cspell_config_directory in pairs(cspell_config_directories) do
+                local cspell_config_path = helpers.get_config_path(params, cspell_config_directory)
+                if cspell_config_path == nil then
+                    cspell_config_path = helpers.generate_cspell_config_path(params, cspell_config_directory)
+                end
+                cspell_config_paths[cspell_config_directory] = cspell_config_path
             end
+            local merged_config = helpers.create_merged_cspell_json(params, cspell_config_paths)
+
+            cspell_args = vim.list_extend({ "-c", merged_config.path }, cspell_args)
 
             local code_action_source = require("null-ls.sources").get({
                 name = "cspell",
@@ -43,11 +57,10 @@ return h.make_builtin({
                 cspell_args = vim.list_extend({ "--show-suggestions" }, cspell_args)
 
                 local code_action_config = code_action_source.config or {}
-                local diagnostics_config = params and params:get_config() or {}
 
                 if helpers.matching_configs(code_action_config, diagnostics_config) then
                     -- warm up the config cache so we have the config ready by the time we call the code action
-                    helpers.async_get_config_info(params)
+                    helpers.async_get_config_info(params, cspell_config_paths[params.cwd])
                 elseif needs_warning then
                     needs_warning = false
                     vim.notify(

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -74,7 +74,18 @@ M.create_merged_cspell_json = function(params, cspell_config_mapping)
     end
 
     for _, cspell_config_path in pairs(cspell_config_mapping) do
-        table.insert(cspell_config_paths, cspell_config_path)
+        local path_exists = cspell_config_path ~= nil
+            and cspell_config_path ~= ""
+            and Path:new(cspell_config_path):exists()
+        if path_exists then
+            table.insert(cspell_config_paths, cspell_config_path)
+        else
+            local debug_message = M.format(
+                'Unable to find file at "${file_path}", skipping adding to merged cspell config.',
+                { file_path = cspell_config_path }
+            )
+            logger:debug(debug_message)
+        end
     end
 
     local cspell_json = {

--- a/tests/spec/diagnostics_spec.lua
+++ b/tests/spec/diagnostics_spec.lua
@@ -11,6 +11,10 @@ local uv = vim.loop
 
 local CSPELL_CONFIG_PATH = uv.fs_realpath("./cspell.json")
 
+local CACHE_KEY = Path:new("."):joinpath("cspell.json"):absolute():gsub("/", "%%")
+
+local CSPELL_MERGED_CONFIG_PATH = Path:new(".tests/cache/nvim/cspell.nvim"):joinpath(CACHE_KEY):expand()
+
 mock(require("null-ls.logger"), true)
 
 describe("diagnostics", function()
@@ -78,7 +82,8 @@ describe("diagnostics", function()
             local add_to_json_action
             local actions = code_actions.generator.fn(generator_params)
             for _, action in ipairs(actions) do
-                if action.title:match("cspell json file") then
+                local expected_action_title = 'to "' .. helpers.shorten_path(generator_params.cwd)
+                if action.title:match(expected_action_title) then
                     add_to_json_action = action
                     break
                 end
@@ -113,7 +118,7 @@ describe("diagnostics", function()
             it("does not include a suggestions param", function()
                 assert.same({
                     "-c",
-                    CSPELL_CONFIG_PATH,
+                    CSPELL_MERGED_CONFIG_PATH,
                     "lint",
                     "--language-id",
                     "lua",
@@ -150,7 +155,7 @@ describe("diagnostics", function()
                 assert.same({
                     "--show-suggestions",
                     "-c",
-                    CSPELL_CONFIG_PATH,
+                    CSPELL_MERGED_CONFIG_PATH,
                     "lint",
                     "--language-id",
                     "lua",
@@ -170,6 +175,7 @@ describe("diagnostics", function()
             after_each(function()
                 get_source:revert()
                 async_get_config_info:revert()
+                Path:new(CSPELL_MERGED_CONFIG_PATH):rm({})
             end)
 
             it("includes a suggestions param", function()
@@ -187,12 +193,20 @@ describe("diagnostics", function()
 
                 assert.same({
                     "-c",
-                    "some/custom/path/cspell.json",
+                    CSPELL_MERGED_CONFIG_PATH,
                     "lint",
                     "--language-id",
                     "lua",
                     "stdin://file.txt",
                 }, args)
+
+                local merged_config = vim.json.decode(Path:new(CSPELL_MERGED_CONFIG_PATH):read())
+
+                assert.is_table(merged_config)
+                assert.truthy(merged_config["import"] ~= nil)
+
+                assert.is_table(merged_config.import)
+                assert.truthy(vim.tbl_contains(merged_config.import, "some/custom/path/cspell.json"))
             end)
         end)
 


### PR DESCRIPTION
- Adds a fix for problem 1 discussed in https://github.com/davidmh/cspell.nvim/issues/61
- Also adds a few more diagnostic spec tests to verify only created files are added to the merged_cspell_config

Let me know if there are any other changes that should be made before multi_config support is enabled again, as this PR reverts the mult_config revert as well as adds the fix discussed in the above issue. 