### PR TITLE
fix: respect language settings of imported files

### DIFF
--- a/lua/cspell/code_actions/init.lua
+++ b/lua/cspell/code_actions/init.lua
@@ -1,5 +1,4 @@
 local make_builtin = require("null-ls.helpers").make_builtin
-local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 local h = require("cspell.helpers")
 local make_add_to_json = require("cspell.code_actions.make_add_to_json")
@@ -55,8 +54,6 @@ return make_builtin({
         ---@param params GeneratorParams
         ---@return table<number, CodeAction>
         fn = function(params)
-            params.cwd = params.cwd or u.get_root()
-
             ---@type CSpellSourceConfig
             local code_action_config =
                 vim.tbl_extend("force", { read_config_synchronously = true }, params:get_config())
@@ -65,7 +62,7 @@ return make_builtin({
             local cspell_config_paths = {}
 
             local cspell_config_directories = code_action_config.cspell_config_dirs or {}
-            table.insert(cspell_config_directories, params.cwd)
+            table.insert(cspell_config_directories, vim.fn.getcwd(-1, -1))
 
             for _, cspell_config_directory in pairs(cspell_config_directories) do
                 local cspell_config_path = h.get_config_path(params, cspell_config_directory)

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -1,4 +1,5 @@
 local h = require("null-ls.helpers")
+local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 local helpers = require("cspell.helpers")
 local parser = require("cspell.diagnostics.parser")
@@ -25,6 +26,7 @@ return h.make_builtin({
                 params.ft,
                 "stdin://" .. params.bufname,
             }
+            helpers.update_params_cwd(params)
 
             ---@type CSpellSourceConfig
             local diagnostics_config = params and params:get_config() or {}
@@ -33,7 +35,7 @@ return h.make_builtin({
             local cspell_config_paths = {}
 
             local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
-            table.insert(cspell_config_directories, vim.fn.getcwd(-1, -1))
+            table.insert(cspell_config_directories, params.cwd)
 
             for _, cspell_config_directory in pairs(cspell_config_directories) do
                 local cspell_config_path = helpers.get_config_path(params, cspell_config_directory)
@@ -59,7 +61,7 @@ return h.make_builtin({
 
                 if helpers.matching_configs(code_action_config, diagnostics_config) then
                     -- warm up the config cache so we have the config ready by the time we call the code action
-                    helpers.async_get_config_info(params, cspell_config_paths[vim.fn.getcwd(-1, -1)])
+                    helpers.async_get_config_info(params, cspell_config_paths[params.cwd])
                 elseif needs_warning then
                     needs_warning = false
                     vim.notify(

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -26,13 +26,15 @@ return h.make_builtin({
                 params.ft,
                 "stdin://" .. params.bufname,
             }
-            helpers.update_params_cwd(params)
+            local force_rewrite = helpers.update_params_cwd(params)
 
             ---@type CSpellSourceConfig
             local diagnostics_config = params and params:get_config() or {}
 
             ---@type table<number|string, string>
-            local cspell_config_paths = params and params:get_config().cspell_import_files or {}
+            local cspell_config_paths = diagnostics_config.cspell_import_files
+                    and diagnostics_config.cspell_import_files(params)
+                or {}
 
             local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
             table.insert(cspell_config_directories, params.cwd)
@@ -44,7 +46,7 @@ return h.make_builtin({
                 end
                 cspell_config_paths[cspell_config_directory] = cspell_config_path
             end
-            local merged_config = helpers.create_merged_cspell_json(params, cspell_config_paths)
+            local merged_config = helpers.create_merged_cspell_json(params, cspell_config_paths, force_rewrite)
 
             cspell_args = vim.list_extend({ "-c", merged_config.path }, cspell_args)
 

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -30,7 +30,7 @@ return h.make_builtin({
             local diagnostics_config = params and params:get_config() or {}
 
             ---@type table<number|string, string>
-            local cspell_config_paths = {}
+            local cspell_config_paths = params and params:get_config().cspell_import_files or {}
 
             local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
             table.insert(cspell_config_directories, vim.fn.getcwd(-1, -1))

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -32,7 +32,7 @@ return h.make_builtin({
             local diagnostics_config = params and params:get_config() or {}
 
             ---@type table<number|string, string>
-            local cspell_config_paths = {}
+            local cspell_config_paths = params and params:get_config().cspell_import_files or {}
 
             local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
             table.insert(cspell_config_directories, params.cwd)

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -1,5 +1,4 @@
 local h = require("null-ls.helpers")
-local u = require("null-ls.utils")
 local methods = require("null-ls.methods")
 local helpers = require("cspell.helpers")
 local parser = require("cspell.diagnostics.parser")

--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -25,7 +25,6 @@ return h.make_builtin({
                 params.ft,
                 "stdin://" .. params.bufname,
             }
-            params.cwd = params.cwd or vim.loop.cwd()
 
             ---@type CSpellSourceConfig
             local diagnostics_config = params and params:get_config() or {}
@@ -34,7 +33,7 @@ return h.make_builtin({
             local cspell_config_paths = {}
 
             local cspell_config_directories = diagnostics_config.cspell_config_dirs or {}
-            table.insert(cspell_config_directories, params.cwd)
+            table.insert(cspell_config_directories, vim.fn.getcwd(-1, -1))
 
             for _, cspell_config_directory in pairs(cspell_config_directories) do
                 local cspell_config_path = helpers.get_config_path(params, cspell_config_directory)
@@ -60,7 +59,7 @@ return h.make_builtin({
 
                 if helpers.matching_configs(code_action_config, diagnostics_config) then
                     -- warm up the config cache so we have the config ready by the time we call the code action
-                    helpers.async_get_config_info(params, cspell_config_paths[params.cwd])
+                    helpers.async_get_config_info(params, cspell_config_paths[vim.fn.getcwd(-1, -1)])
                 elseif needs_warning then
                     needs_warning = false
                     vim.notify(

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -84,7 +84,8 @@ end
 M.get_merged_cspell_json_path = function(params)
     local vim_cache = vim.fn.stdpath("cache")
     local plugin_name = "cspell.nvim"
-    local merged_config_key = Path:new(params.cwd):joinpath("cspell.json"):absolute():gsub("/", "-"):gsub(":", "")
+    local merged_config_key =
+        Path:new(vim.fn.getcwd(-1, -1)):joinpath("cspell.json"):absolute():gsub("\\", "-"):gsub("/", "-"):gsub(":", "")
     local merged_config_path = Path:new(vim_cache):joinpath(plugin_name):joinpath(merged_config_key):absolute()
 
     return merged_config_path

--- a/lua/cspell/helpers.lua
+++ b/lua/cspell/helpers.lua
@@ -92,16 +92,14 @@ M.create_merged_cspell_json = function(params, cspell_config_mapping)
             and cspell_config_path ~= ""
             and Path:new(cspell_config_path):exists()
         if path_exists then
-            pcall(function()
-                local cspell_config = vim.json.decode(Path:new(cspell_config_path):read())
-                if
-                    cspell_config.language ~= nil
-                    and type(cspell_config.language) == "string"
-                    and cspell_config.language ~= ''
-                then
-                    cspell_json.language = cspell_json.language .. "," .. cspell_config.language
-                end
-            end)
+            local ok, cspell_config = pcall(vim.json.decode, Path:new(cspell_config_path):read())
+            if ok
+                and cspell_config.language ~= nil
+                and type(cspell_config.language) == "string"
+                and cspell_config.language ~= ''
+            then
+                cspell_json.language = cspell_json.language .. "," .. cspell_config.language
+            end
             table.insert(cspell_config_paths, cspell_config_path)
         else
             local debug_message = M.format(

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -1,0 +1,1 @@
+nvim --headless --noplugin -u tests/minimal_init.lua -c "lua require('plenary.test_harness').test_directory_command('tests/spec {minimal_init = \"tests/minimal_init.lua\"}')"


### PR DESCRIPTION
cspell only respects the language of the main config, thus making it impossible to add new languages exclusively by importing them. This pull request appends all the languages found in imported files to the main config automatically.

Fixes #74 