### PR TITLE
docs(README): correct depends to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ return {
   {
     "nvimtools/none-ls.nvim",
     event = "VeryLazy",
-    depends = { "davidmh/cspell.nvim" },
+    dependencies = { "davidmh/cspell.nvim" },
     opts = function(_, opts)
       local cspell = require("cspell")
       opts.sources = opts.sources or {}


### PR DESCRIPTION
The lazy.nvim install instructions incorrectly have `depends` rather than `dependencies` https://lazy.folke.io/spec#spec-loading