### PR TITLE
feat: use npx to run cspell

### DIFF
--- a/lua/cspell/diagnostics/init.lua
+++ b/lua/cspell/diagnostics/init.lua
@@ -16,7 +16,7 @@ return h.make_builtin({
     method = DIAGNOSTICS,
     filetypes = {},
     generator_opts = {
-        command = "cspell",
+        command = "npx",
         ---@param params GeneratorParams
         args = function(params)
             local cspell_args = {
@@ -70,6 +70,8 @@ return h.make_builtin({
                     )
                 end
             end
+
+            cspell_args = vim.list_extend({ "--no-install", "cspell" }, cspell_args)
 
             return cspell_args
         end,

--- a/tests/spec/diagnostics_spec.lua
+++ b/tests/spec/diagnostics_spec.lua
@@ -117,6 +117,8 @@ describe("diagnostics", function()
 
             it("does not include a suggestions param", function()
                 assert.same({
+                    "--no-install",
+                    "cspell",
                     "-c",
                     CSPELL_MERGED_CONFIG_PATH,
                     "lint",
@@ -153,6 +155,8 @@ describe("diagnostics", function()
 
             it("includes a suggestions param", function()
                 assert.same({
+                    "--no-install",
+                    "cspell",
                     "--show-suggestions",
                     "-c",
                     CSPELL_MERGED_CONFIG_PATH,
@@ -196,6 +200,8 @@ describe("diagnostics", function()
                     })
 
                     assert.same({
+                        "--no-install",
+                        "cspell",
                         "-c",
                         CSPELL_MERGED_CONFIG_PATH,
                         "lint",
@@ -239,6 +245,8 @@ describe("diagnostics", function()
                     })
 
                     assert.same({
+                        "--no-install",
+                        "cspell",
                         "-c",
                         CSPELL_MERGED_CONFIG_PATH,
                         "lint",


### PR DESCRIPTION
I have CSpell installed per project rather than globally so the command fails as it can't find CSpell on the environment path.
CSpell requires node, node comes with npx, npx can find CSpell install on the environment path or local node_modules